### PR TITLE
Corrections and additions to alpha/beta/tolerance setters

### DIFF
--- a/src/usfirst/frc/team2168/robot/FalconPathPlanner.java
+++ b/src/usfirst/frc/team2168/robot/FalconPathPlanner.java
@@ -593,12 +593,22 @@ public class FalconPathPlanner
 
 	public void setPathBeta(double beta)
 	{
-		pathAlpha = beta;
+		pathBeta = beta;
 	}
 
 	public void setPathTolerance(double tolerance)
 	{
-		pathAlpha = tolerance;
+		pathTolerance = tolerance;
+	}
+	
+	public void setVelocityAlpha(double alpha)
+	{
+		velocityAlpha = alpha;
+	}
+	
+	public void setVelocityBeta(double beta)
+	{
+		velocityBeta = beta;
 	}
 
 	/**


### PR DESCRIPTION
This is just a simple change that corrects the setters for pathBeta and pathTolerance, which were previously setting pathAlpha in each method.  I also added setters for velocityAlpha and velocityBeta.  We've tested these in the plotter and on our 2016 robot and all updates appear to work as intended.
